### PR TITLE
CASMCMS-7308: Update base chart and enabled postgres backups

### DIFF
--- a/kubernetes/gitea/requirements.yaml
+++ b/kubernetes/gitea/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: cray-service
-  version: "~2.4.7"
+  version: "~2.7.0"
   repository: "@cray-internal"

--- a/kubernetes/gitea/values.yaml
+++ b/kubernetes/gitea/values.yaml
@@ -115,6 +115,9 @@ cray-service:
       service_account: []
     databases:
       service_db: service_account
+    backup:
+      enabled: true
+      schedule: "10 1 * * *" # Once per day at 1:10AM
   ingress:
     enabled: false
     # turning off base chart for ingress


### PR DESCRIPTION
This cherry-picks the following change over from stash to github. This change was previously reviewed and approved when it merged to stash, but I am too lazy to go dig up its review template.

CASMCMS-7308: Update base chart and enabled postgres backups