### PR TITLE
CASMINST-2947: Do not append global appVersion stanza to gitea values.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ lint:
 
 chart_setup:
 		mkdir -p ${CHART_PATH}/.packaged
-		printf "\nglobal:\n  appVersion: ${GITEA_DOCKER_VERSION}" >> ${CHART_PATH}/${NAME}/values.yaml
 
 chart_package:
 		helm dep up ${CHART_PATH}/${NAME}


### PR DESCRIPTION
### Summary and Scope
gitea-vcs was failing to deploy during csm-1.0 and csm-1.1 upgrades on surtur and drax. It turned out that having the global appVersion stanza in its values.yaml was causing the deploy to fail. I am not sure why that is the case, but removing it solved the deploy problem on both systems.

### Issues and Related PRs
This was also the true root cause of two tickets from last week. We thought they were caused by our build picking up code from the unstable branch, but it turned out that this was a red herring.
* CASMINST-2921
* CASMTRIAGE-2133

### Testing
I verified that removing that stanza allowed the deploys to proceed on both drax and surtur. In the case of drax, there was a further issue, but it is unrelated to this. On surtur, gitea came up fine and I ran our vcs tests on it successfully.

### Risks and Mitigations
Low risk.