### PR TITLE
CASMCMS-7545: Allow gitea to run its containers as root

### DIFF
--- a/kubernetes/gitea/values.yaml
+++ b/kubernetes/gitea/values.yaml
@@ -45,6 +45,13 @@ cray-service:
         postStart:
           exec:
             command: ["/bin/bash", "-c", "su - git -c /mnt/gitea-files/setup.sh"]
+      # For the moment we need to have gitea running as root, until we get the rootless
+      # image working and the corresponding steps to migrate from the rooted image to the
+      # rootless image
+      securityContext:
+        runAsGroup: 0
+        runAsNonRoot: false
+        runAsUser: 0
       volumeMounts:
       - name: vcs-data-vol
         mountPath: /data
@@ -106,6 +113,13 @@ cray-service:
               sed -i \"81s/^$/PASSWD = $POSTGRES_PASSWD/\" /data/gitea/conf/app.ini &&
               SECRET_KEY=$(cat /dev/random | tr -cd '[:alnum:]' | head -c 64) &&
               sed -i \"s/PUT_RANDOM_SECRET_KEY_HERE/$SECRET_KEY/\" /data/gitea/conf/app.ini"]
+      # For the moment we need to have gitea running as root, until we get the rootless
+      # image working and the corresponding steps to migrate from the rooted image to the
+      # rootless image
+      securityContext:
+        runAsGroup: 0
+        runAsNonRoot: false
+        runAsUser: 0
   sqlCluster:
     enabled: true
     instanceCount: 3


### PR DESCRIPTION
### Summary and Scope
non-root enablement happened accidentally for gitea when its base service chart was updated for unrelated reasons. This broke it. The fix to make non-root work for gitea turns out to be non-trivial, but we want gitea working on csm-1.1 in the meantime. This PR adds the overrides necessary to have gitea continue to run as root until we get rootless working. 

### Issues and Related PRs
* CASMCMS-7546: I have opened this ticket to track the non-root enablement for gitea

### Testing
I deployed this on drax (where we discovered it was broken) and verified that gitea starts up fine. I ran our cmsdev vcs tests on it and they all passed.

### Risks and Mitigations
Low risk. Without this, VCS doesn't work, so....