### PR TITLE
CASMCMS-7636: Use explicit URL in requirements.yaml instead of alias

### DIFF
--- a/kubernetes/gitea/requirements.yaml
+++ b/kubernetes/gitea/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: cray-service
   version: "~2.4.7"
-  repository: "@cray-algol60"
+  repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"


### PR DESCRIPTION
Per the esteemed Zach Crisler, our requirements.yaml files should not be using an alias (such as @cray-algol60) but should instead be using an explicit URL. This PR makes that change (using the URL provided by Zach). No testing has been done beyond making sure the build works, since the alias should have just ended up pointing to this URL anyway.