### PR TITLE
CASMCMS-7754: Use patch and signed alpine image; Do not pin alpine patch version

### DIFF
--- a/kubernetes/gitea/Chart.yaml
+++ b/kubernetes/gitea/Chart.yaml
@@ -22,7 +22,7 @@ annotations:
     - name: gitea
       image: artifactory.algol60.net/csm-docker/stable/docker.io/gitea/gitea:0.0.0-gitea
     - name: alpine
-      image: artifactory.algol60.net/docker.io/library/alpine:3.13.5
+      image: artifactory.algol60.net/docker.io/library/alpine:3.13
     - name: alpine
       image: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup:1.0.0
   artifacthub.io/license: MIT

--- a/kubernetes/gitea/Chart.yaml
+++ b/kubernetes/gitea/Chart.yaml
@@ -22,7 +22,7 @@ annotations:
     - name: gitea
       image: artifactory.algol60.net/csm-docker/stable/docker.io/gitea/gitea:0.0.0-gitea
     - name: alpine
-      image: artifactory.algol60.net/docker.io/library/alpine:3.13
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.13
     - name: alpine
       image: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup:1.0.0
   artifacthub.io/license: MIT

--- a/kubernetes/gitea/values.yaml
+++ b/kubernetes/gitea/values.yaml
@@ -86,7 +86,7 @@ cray-service:
     setup-config:
       name: setup-config
       image:
-        repository: artifactory.algol60.net/docker.io/library/alpine
+        repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine
         tag: 3.13
       env:
       - name: POSTGRES_USER
@@ -120,7 +120,7 @@ cray-service:
     setup-rootless:
       name: setup-rootless
       image:
-        repository: artifactory.algol60.net/docker.io/library/alpine
+        repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine
         tag: 3.13
       env:
       volumeMounts:

--- a/kubernetes/gitea/values.yaml
+++ b/kubernetes/gitea/values.yaml
@@ -87,7 +87,7 @@ cray-service:
       name: setup-config
       image:
         repository: artifactory.algol60.net/docker.io/library/alpine
-        tag: 3.13.5
+        tag: 3.13
       env:
       - name: POSTGRES_USER
         valueFrom:
@@ -121,7 +121,7 @@ cray-service:
       name: setup-rootless
       image:
         repository: artifactory.algol60.net/docker.io/library/alpine
-        tag: 3.13.5
+        tag: 3.13
       env:
       volumeMounts:
       - name: vcs-data-vol


### PR DESCRIPTION
## Summary and Scope

Modify the gitea chart so that it uses the internally patched and signed Alpine image. In addition, do not pin the patch number of the alpine image, so that we get the latest patch version of it.

## Issues and Related PRs

None.

## Testing

Confirmed build worked as expected. Applied patched chart on wasp and verified that gitea still passed CT tests.

## Risks and Mitigations

Fairly low risk, and better than going with an image that has CVEs.

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [N/A] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

