### PR TITLE
CASMCMS-7824 - Update keycloak version.

### DIFF
--- a/kubernetes/gitea/Chart.yaml
+++ b/kubernetes/gitea/Chart.yaml
@@ -23,6 +23,6 @@ annotations:
       image: artifactory.algol60.net/csm-docker/stable/docker.io/gitea/gitea:0.0.0-gitea
     - name: alpine
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.13
-    - name: alpine
-      image: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup:1.0.0
+    - name: cray-keycloak-setup
+      image: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup:3.1.1
   artifacthub.io/license: MIT

--- a/kubernetes/gitea/values.yaml
+++ b/kubernetes/gitea/values.yaml
@@ -165,5 +165,5 @@ keycloakMasterAdminSecretName: keycloak-master-admin-auth
 keycloakBase: http://cray-keycloak-http/keycloak
 keycloakImage:
   repository: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup
-  tag: 1.0.0
+  tag: 3.1.1
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope

The gitea initialization job was using an old version of keycloak that contained CVE vulnerabilities.  This updates to use the latest version of cray-keycloak-setup.

## Issues and Related PRs
* Resolves [CASMCMS-7824](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7824)
* Resolves [CASMCMS-7825](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7825)

## Testing
### Tested on:

  * `Mug`

### Test description:

Installed the new version of gitea chart on Mug through a helm upgrade.  We watched the initialization job run and verified it was able to connect to keycloak and check / update the required users in keycloak.  As this image is only used during an initialization job, a downgrade test was not required.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N - not required
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be a low risk change as we are upgrading to the current keycloak version and testing verified it worked correctly on an installed system.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

