### PR TITLE
CASMCMS-7891: Modify setup script to handle passwords beginning with dashes

### DIFF
--- a/kubernetes/gitea/files/setup.sh
+++ b/kubernetes/gitea/files/setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-# Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -13,14 +16,12 @@
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# (MIT License)
-
 # Create the admin user for gitea
 
 DATA_MOUNT=/var/lib/gitea

--- a/kubernetes/gitea/files/setup.sh
+++ b/kubernetes/gitea/files/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -72,13 +72,15 @@ CRAYVCS_PASSWORD=$(</mnt/crayvcs-credentials/vcs_password)
 CRAYVCS_USER_EMAIL="${CRAYVCS_USER}@mgmt-plane-nmn.local"
 cd ${DATA_MOUNT}/custom
 echo "Running in `pwd`" >> $LOG_FILE
+# The password argument must go last because if it happens to begin with
+# a dash, it causes problems if it is not last.
 /usr/local/bin/gitea admin user create \
     --config ${DATA_MOUNT}/app.ini \
     --username ${CRAYVCS_USER} \
-    --password ${CRAYVCS_PASSWORD} \
     --admin \
     --must-change-password=false \
-    --email "${CRAYVCS_USER_EMAIL}" &>> $LOG_FILE
+    --email "${CRAYVCS_USER_EMAIL}" \
+    --password "${CRAYVCS_PASSWORD}" &>> $LOG_FILE
 
 RESULT=$?
 if [ $RESULT == 0 ]; then


### PR DESCRIPTION
## Summary and Scope

The gitea setup script is responsible for creating the gitea admin user. It does this using a command line call to gitea. On wasp there was a problem where calls to gitea were failing with authentication errors, even after verifying that the correct credentials were being used. The issue turned out to be that the password began with a dash, and this was causing the gitea command to interpret it as a flag. Moving the password argument to the end of the command line resolves the issue.

## Issues and Related PRs

csm 1.0 backport of this change:
https://github.com/Cray-HPE/gitea/pull/17

## Testing

I manually tested the fix on wasp in the current gitea container. I also removed gitea and redeployed it using the new chart, and verified that the updated setup script was able to successfully create the user.

## Risks and Mitigations

Low risk -- the change just involves switching the order of the command line arguments.

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

