### PR TITLE
CASMCMS-7901: Enable tls for sqlCluster (1.2)

### DIFF
--- a/kubernetes/gitea/values.yaml
+++ b/kubernetes/gitea/values.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 # Please refer to https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/values.yaml
 # for more info on values you can set/override
 # Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
@@ -155,6 +178,8 @@ cray-service:
     backup:
       enabled: true
       schedule: "10 1 * * *"  # Once per day at 1:10AM
+    tls:
+      enabled: true
   ingress:
     enabled: false
     # turning off base chart for ingress


### PR DESCRIPTION
## Summary and Scope

Enables tls to fix a bug in the postgres operator when upgrading from 1.0 to 1.2

## Issues and Related PRs

* Resolves CASMCMS-7901

## Testing

### Tested on:

  * Hela

### Test description:

- Installed the chart and verified the the postgres cluster was working.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

