### PR TITLE
Increment base chart version for updated istio SSL logic

### DIFF
--- a/kubernetes/gitea/Chart.yaml
+++ b/kubernetes/gitea/Chart.yaml
@@ -33,7 +33,7 @@ sources:
 - https://github.com/Cray-HPE/gitea
 dependencies:
 - name: cray-service
-  version: ^8.0.0
+  version: ^8.2.0
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts/
 maintainers:
 - name: rbak-hpe


### PR DESCRIPTION
## Summary and Scope

A newer version of istio changed its general configuration for which addresses it would treat as a means of ignoring ssl/ttl between pods from 127.0.0.1 to 127.0.0.6.  The PET team published a new service chart (8.2.0) that provides proper configuration for istio, but all affected charts need to be updated to this new version.

## Issues and Related PRs

Resolves CASMINST-5147.

## Testing

Install testing on older systems (1.2) which tests a do-no-harm. More further in-depth testing for this particular chart was accomplished by the PET team specific to gitea.

### Tested on:

  * Virtual Shasta (PET)
  *  Groot/1.2

### Test description:

Deployed and verified that the new chart was backwards compatible with an older version of istio. No other physical hardware systems with a fresh install of 1.3 were available for testing.

## Risks and Mitigations

Low risk.