### PR TITLE
CASMINST-5250 - handle odd gitea user passwords.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- CASMINST-5250 - fix gitea user creation to handle passwords with leading '-'
+- CASMPET-5864 - update keycloak-setup default image version.
 
 ### Removed
 

--- a/kubernetes/gitea/Chart.yaml
+++ b/kubernetes/gitea/Chart.yaml
@@ -47,5 +47,5 @@ annotations:
     - name: alpine
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.13
     - name: cray-keycloak-setup
-      image: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup:3.1.1
+      image: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup:3.6.1
   artifacthub.io/license: MIT

--- a/kubernetes/gitea/files/setup.sh
+++ b/kubernetes/gitea/files/setup.sh
@@ -81,7 +81,7 @@ echo "Running in `pwd`" >> $LOG_FILE
     --admin \
     --must-change-password=false \
     --email "${CRAYVCS_USER_EMAIL}" \
-    --password "${CRAYVCS_PASSWORD}" &>> $LOG_FILE
+    --password="${CRAYVCS_PASSWORD}" &>> $LOG_FILE
 
 RESULT=$?
 if [ $RESULT == 0 ]; then

--- a/kubernetes/gitea/values.yaml
+++ b/kubernetes/gitea/values.yaml
@@ -190,5 +190,5 @@ keycloakMasterAdminSecretName: keycloak-master-admin-auth
 keycloakBase: http://cray-keycloak-http/keycloak
 keycloakImage:
   repository: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup
-  tag: 3.1.1
+  tag: 3.6.1
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope

This is a slight addition to the base fix for handling a password with a leading '-' char.  By putting the explicit '--password=' it will continue to work correctly even if additional arguments are added after this in the gitea command to create a new user.

## Issues and Related PRs
* Resolves [CASMINST-5250](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5250)

## Testing
### Tested on:
  * `Fanta`

### Test description:

I installed the new version of the gitea helm chart using loftsman with a customized manifest.  As there wasn't an actual image change (gitea repo is only a helm chart) I had to uninstall the old version, then install the new one to get it to take effect.  When the new version was installed and started I verified the password used still has a leading `-` char, and the vcs user was created successfully.

I then restarted the config-import job that had been hung up due to the invalid gitea user problem, and it successfully imported it's content into vcs.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a pretty low risk change as it is a slight tweak on the old fix.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

