### PR TITLE
v2.5.0 - Release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+### Removed
+### Changed
 
+[2.5.0] - 2022-08-22
 ### Changed
 - CASMINST-5250 - fix gitea user creation to handle passwords with leading '-'
 - CASMPET-5864 - update keycloak-setup default image version.
-
-### Removed
-
-### Added
 
 [1.0.0] - (no date)


### PR DESCRIPTION
## Summary and Scope

v2.5.0 Release
- CASMINST-5250 - fix gitea user creation to handle passwords with leading '-'
- CASMPET-5864 - update keycloak-setup default image version.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

