### PR TITLE
CASMCMS-8248: Fix reverse proxy authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.3] - 2023-1-27
+### Fixed
+- Fixed reverse proxy authentication
+
 ## [2.5.2] - 2022-12-20
 ### Added
 - Add Artifactory authentication to Jenkinsfile
-
-## [Unreleased]
-### Added
-### Removed
-### Changed
 
 [2.5.0] - 2022-08-22
 ### Changed

--- a/kubernetes/gitea/templates/config.yaml
+++ b/kubernetes/gitea/templates/config.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -128,8 +128,8 @@ data:
     ; !!CHANGE THIS TO KEEP YOUR USER DATA SAFE!!
     SECRET_KEY = PUT_RANDOM_SECRET_KEY_HERE
     ; For reverse proxy
-    REVERSE_PROXY_AUTHENTICATION_USER = X-Auth-Userid
-    REVERSE_PROXY_AUTHENTICATION_EMAIL = X-Auth-Email
+    REVERSE_PROXY_AUTHENTICATION_USER = x-forwarded-preferred-username
+    REVERSE_PROXY_AUTHENTICATION_EMAIL = x-forwarded-email
 
     [service]
     ; Whether a new user needs to confirm their email when registering.
@@ -151,7 +151,7 @@ data:
     ; Enable reverse proxy
     ENABLE_REVERSE_PROXY_AUTHENTICATION = true
     ENABLE_REVERSE_PROXY_AUTO_REGISTRATION = true
-    ENABLE_REVERSE_PROXY_EMAIL = true
+    ENABLE_REVERSE_PROXY_EMAIL = false
 
     [mailer]
     ENABLED = false


### PR DESCRIPTION
## Summary and Scope

Fixes reverse proxy authentication so that logging into the UI through keycloak also logs users into gitea.  The headers changed when we switched from keycloak-gatekeeper to oauth2-proxy.

## Issues and Related PRs

* Resolves CASMCMS-8248

## Testing

### Tested on:

  * Surtur

### Test description:

Successfully logged into the UI through keycloak

## Risks and Mitigations

No


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

