### PR TITLE
CASMCMS-8512: Fix typo in chart causing logical DB backups to be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- CASMCMS-8512 - Fix typo in Chart that causes logical DB backups to be disabled.
+
 ## [2.6.0] - 2023-03-23
+
 ### Changed
 - CASMCMS-8457 - Update chart to use new postgres operator
 
 ## [2.5.3] - 2023-1-27
+
 ### Fixed
 - Fixed reverse proxy authentication
 
 ## [2.5.2] - 2022-12-20
+
 ### Added
 - Add Artifactory authentication to Jenkinsfile
 
-[2.5.0] - 2022-08-22
+## [2.5.0] - 2022-08-22
+
 ### Changed
 - CASMINST-5250 - fix gitea user creation to handle passwords with leading '-'
 - CASMPET-5864 - update keycloak-setup default image version.
-
-[1.0.0] - (no date)

--- a/kubernetes/gitea/values.yaml
+++ b/kubernetes/gitea/values.yaml
@@ -185,9 +185,8 @@ cray-postgresql:
       service_account: []
     databases:
       service_db: service_account
-    sqlCluster:
-      enableLogicalBackup: true
-      logicalBackupSchedule: "10 1 * * *"  # Once per day at 1:10AM
+    enableLogicalBackup: true
+    logicalBackupSchedule: "10 1 * * *"  # Once per day at 1:10AM
     tls:
       enabled: true
 


### PR DESCRIPTION
## Summary and Scope

The changes in [CASMCMS-8457](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8457) included a small mistake which had the result that the logical database backups were disabled for VCS. This PR corrects that mistake. Big thanks to Kim Jensen for helping to figure out the source of this problem.

## Issues and Related PRs

- Resolves [CASMCMS-8512](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8512)
- Bug injected by [CASMCMS-8457](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8457)
- Bug discovered by [CASMTRIAGE-5130](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5130)
- The cmsdev test tool will need to be updated to reflect this new database backup scheme. That's being done with [CASMCMS-8513](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8513)

## Testing

I tested the corrected chart on yasha (the CSM 1.5 vshasta system where the error was seen) and verified that it caused the backups to be enabled.

Before the change:

```text
ncn-w002:~/mitch # kubectl get cronjobs -A | grep vcs
ncn-w002:~/mitch # kubectl get -n services  postgresql gitea-vcs-postgres -o yaml
...
  enableLogicalBackup: false
...
```

After the change
```text
ncn-w002:~/mitch # kubectl get cronjobs -A | grep vcs
services      logical-backup-gitea-vcs-postgres     10 1 * * *     False     0        <none>          2m37s
ncn-w002:~/mitch # kubectl get -n services  postgresql gitea-vcs-postgres -o yaml
...
  enableLogicalBackup: false
...
```

## Risks and Mitigations

Low risk. And without this change, the DB will not be backed up.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
