### PR TITLE
CASMCMS-7594/7595: Adds the CMN gateway to virtual services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.6.2] - 2023-05-03
+
+### Changed
+
+- CASMCMS-7594 - Added the CMN gateway to both virtual services.
+
 ## [2.6.1] - 2023-04-06
 
 ### Changed

--- a/kubernetes/gitea/templates/virtualservice.yaml
+++ b/kubernetes/gitea/templates/virtualservice.yaml
@@ -34,6 +34,7 @@ metadata:
 spec:
   gateways:
   - services-gateway
+  - customer-admin-gateway
   hosts:
   - '*'
   http:
@@ -60,7 +61,8 @@ metadata:
     app.kubernetes.io/name: gitea-vcs
 spec:
   gateways:
-  - {{ .Values.global.authGateway }}
+  - services-gateway
+  - customer-admin-gateway
   hosts:
   - {{ .Values.externalHostname }}
   http:

--- a/kubernetes/gitea/values.yaml
+++ b/kubernetes/gitea/values.yaml
@@ -32,8 +32,6 @@
 
 externalHostname: vcs.local
 uriPrefix: /vcs
-global:
-  authGateway: services/services-gateway
 
 cray-service:
   storageClass: ceph-cephfs-external


### PR DESCRIPTION
## Summary and Scope

Fixes the gateways for the VCS virtual services to include the CMN gateway.

## Issues and Related PRs

* Resolves CASMCMS-7594
* Resolves CASMCMS-7595

## Testing

### Tested on:

  * Mug

### Test description:

Deployed and validated that I could still access VCS.  I'm not sure how much other testing can be done until the CMN work is completed.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

