### PR TITLE
CASMPET-6571: Fix POSTGRES_HOST value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.6.3] - 2023-05-17
+
+### Fixed
+
+- CASMPET-6571 - Fixed incorrect POSTGRES_HOST value.
+
 ## [2.6.2] - 2023-05-03
 
 ### Changed

--- a/kubernetes/gitea/values.yaml
+++ b/kubernetes/gitea/values.yaml
@@ -121,7 +121,7 @@ cray-service:
             name: service-account.gitea-vcs-postgres.credentials
             key: password
       - name: POSTGRES_HOST
-        value: cray-console-data-postgres
+        value: gitea-vcs-postgres
       - name: POSTGRES_PORT
         value: "5432"
       volumeMounts:


### PR DESCRIPTION
## Summary and Scope

Fixes the POSTGRES_HOST value that was added during the move to the new postgres base chart.

## Issues and Related PRs

* Resolves CASMPET-6571

## Testing

### Tested on:

  * Drax

### Test description:

Successfully deployed VCS

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

