### PR TITLE
CASMCMS-9011: Bump cray-keycloak-setup version; use update_external_versions to find it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Dependencies
 - Bump `actions/checkout` from 3 to 4 ([#53](https://github.com/Cray-HPE/gitea/pull/53))
 - Bump `stefanzweifel/git-auto-commit-action` from 4 to 5 ([#54](https://github.com/Cray-HPE/gitea/pull/54))
+- CASMCMS-9011: Bump `cray-keycloak-setup` version from 3.6.1 to 3.7.X; use `update_external_versions` to find latest 3.7.X version
 
 ## [2.6.3] - 2023-05-17
 

--- a/kubernetes/gitea/Chart.yaml
+++ b/kubernetes/gitea/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -50,5 +50,5 @@ annotations:
     - name: alpine
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.13
     - name: cray-keycloak-setup
-      image: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup:3.6.1
+      image: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup:0.0.0-keycloak
   artifacthub.io/license: MIT

--- a/kubernetes/gitea/values.yaml
+++ b/kubernetes/gitea/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -193,5 +193,5 @@ keycloakMasterAdminSecretName: keycloak-master-admin-auth
 keycloakBase: http://cray-keycloak-http/keycloak
 keycloakImage:
   repository: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup
-  tag: 3.6.1
+  tag: 0.0.0-keycloak
   pullPolicy: IfNotPresent

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -1,0 +1,83 @@
+# All default values mentioned below are the defaults of the latest_versions tool. If a field
+# is not specified, the update_external_versions tool simply does not pass that argument
+# to the latest_versions tool. So in case of conflicting information, the defaults described
+# in that tool are the ones you should follow.
+
+# This file contains any number of stanzas of the following form:
+#
+#image: image_name
+#    major: major number
+#    minor: minor number
+#    outfile: target filename
+#    server: arti or algol60
+#    source: docker or helm
+#    team: team name
+#    type: build type
+#    url: url of repository.catalog (for docker) or index.yaml (for helm)
+#
+# For each such stanza, the only required field is the image field. This field
+# determines the name of the image whose latest version we wish to discover.
+#
+# The major and minor fields, if present, must contain nonnegative integers.
+# If specified, they constrain the image version search to versions with the
+# specified major and (if specified) minor number. If neither is specified, the
+# overall latest version of the image will be sought.
+#
+# outfile defines the name of the file that the version will be written to.
+# If not specified, it defaults to <image_name>.version
+#
+# server specifies whether the image search should be done on arti.dev or algol60.net
+# If not specified, it defaults to algol60
+#
+# If source is not specified, it defaults to docker.
+# If team is not specified, it defaults to csm.
+#
+# The source, team, and type fields specify where on the server the image search should be done.
+#
+################
+# server: arti #
+################
+#
+# For arti, if type is not specified, it defaults to stable
+#
+# For source docker, the image version will be based on the information found in:
+# https://arti.hpc.amslabs.hpecorp.net/artifactory/<team>-docker-<type>-local/repository.catalog
+#
+# For source helm, the image version will be based on the information found in:
+# https://arti.hpc.amslabs.hpecorp.net/artifactory/<team>-helm-<type>-local/index.yaml
+#
+###################
+# server: algol60 #
+###################
+#
+# For algol60, if type is not specified, it defaults to stable
+#
+# For source docker, the image version will be based on the information found in:
+# https://artifactory.algol60.net/artifactory/<team>-docker/repository.catalog
+#
+# For source helm, the image version will be based on the information found in:
+# https://artifactory.algol60.net/artifactory/<team>-helm-charts/index.yaml
+#
+# For algol60, the type field is used within these files to distinguish between
+# stable and unstable images by looking at the path to the images.
+#
+#######
+# url #
+#######
+#
+# The url field is mutually exclusive with the following fields: server and team
+# It allows you to instead point the tool directly to the file it should retrieve to
+# use as its image index.
+# For source docker, it will assume the file is in the same JSON format as the repository.catalog
+# files found on arti.dev or algol60
+# For source helm, it will assume the file is in the same YAML format as the index.yaml files
+# found on arti.dev or algol60
+# When the url field is used, there is no default type. Thus, if the specified file includes
+# the image type in the file paths (like on algol60), the type must be explicitly specified or
+# no images will be found. Alternatively, if the specified file does NOT include the image type
+# in the file paths (like on arti.dev), the type parameter should be omitted entirely, otherwise
+# no images will be found.
+
+image: cray-keycloak-setup
+    major: 3
+    minor: 7

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -25,3 +25,8 @@ targetfile: kubernetes/gitea/Chart.yaml
 sourcefile: .chart_version
 tag: 0.0.0-chart
 targetfile: kubernetes/gitea/Chart.yaml
+
+sourcefile: cray-keycloak-setup.version
+tag: 0.0.0-keycloak
+targetfile: kubernetes/gitea/values.yaml
+targetfile: kubernetes/gitea/Chart.yaml


### PR DESCRIPTION
We've been asked to move up from our outdated version of cray-keycloak-setup. This PR does that, and uses update_external_versions to find the latest stable patch version