### PR TITLE
CASMCMS-9133 - update cray-service base chart version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Dependencies
+- CASMCMS-9133 - update the cray-service base chart to 11.0.0 for k8s 1.24.
 
 ## [2.7.0] - 2024-07-01
 
 ### Changed
-
 - Disabled concurrent Jenkins builds on same branch/commit
 - Added build timeout to avoid hung builds
 - Replaced Randy Kleinman with Mitch Harding as maintainter

--- a/kubernetes/gitea/Chart.yaml
+++ b/kubernetes/gitea/Chart.yaml
@@ -33,7 +33,7 @@ sources:
 - https://github.com/Cray-HPE/gitea
 dependencies:
 - name: cray-service
-  version: ~10.0.5
+  version: ~11.0.0
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts/
 - name: cray-postgresql
   version: ^1.0.0


### PR DESCRIPTION
## Summary and Scope

In order to be compatible with csm 1.6.0, the cray-services base chart needed to be updated to 11.0.0.

## Issues and Related PRs
* Resolves [CASMCMS-9134](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9134)

## Testing
### Tested on:
  * `Fanta`

### Test description:

Installed new helm chart via loftsman manifest. Once installed, I verified that the ara UI was functioning correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be a low risk with the only change to the cray-services base chart.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
